### PR TITLE
Setup spring automatically

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,6 +8,9 @@ set -e
 # Set up Ruby dependencies via Bundler
 bundle install
 
+# Spring setup
+spring binstub rspec
+
 # Add binstubs to PATH in ~/.zshenv like this:
 #   export PATH=".git/safe/../../bin:$PATH"
 mkdir -p .git/safe


### PR DESCRIPTION
# WHY?

In Upcase's Weekly Iteration Joe and Ben start an app from zero. They face some issues when running into it. Approximately at 3:40, Joe's get's surprised that suspenders do not setup Spring as part of its own initial setup.
# HOW?

It set up spring in the project, using the recommended command line from [spring's own Readme](https://github.com/rails/spring#setup) 
# SIDE-EFFECTS

None
